### PR TITLE
Fixing o-create-GG-alignment-template-from-taxon 

### DIFF
--- a/bin/o-create-GG-alignment-template-from-taxon
+++ b/bin/o-create-GG-alignment-template-from-taxon
@@ -20,7 +20,7 @@ def get_ids (taxon, otu_id_to_greengenes):
     otu = open(otu_id_to_greengenes)
     for line in otu.readlines():
         try:
-            id, tax in line.strip().split('\t')
+            id, tax = line.strip().split('\t')
             if tax.find (taxon) > 0:
                 ids.append(id)
         except ValueError:

--- a/bin/o-create-GG-alignment-template-from-taxon
+++ b/bin/o-create-GG-alignment-template-from-taxon
@@ -14,15 +14,22 @@ import argparse
 
 import Oligotyping.lib.fastalib as u
 
+def get_ids (taxon, otu_id_to_greengenes):
+    ids = []
+
+    otu = open(otu_id_to_greengenes)
+    for line in otu.readlines():
+        try:
+            id, tax in line.strip().split('\t')
+            if tax.find (taxon) > 0:
+                ids.append(id)
+        except ValueError:
+            print (line)
+    return ids
 
 def gen_tmpl(taxon, otu_id_to_greengenes, greengenes_alignment, output_file_path = None):
-    ids = []
-    
-    for id, tax in [line.strip().split('\t') for line in open(otu_id_to_greengenes).readlines()]:
-        if tax.find(taxon) > 0:
-            ids.append(id)
-    
-    ids = list(set(ids))
+    ids = list(set(get_ids(taxon, otu_id_to_greengenes)))
+
     print '%d ids found for %s.' % (len(ids), taxon)
     
     template = u.FastaOutput('%s.tmpl' % taxon)

--- a/bin/o-create-GG-alignment-template-from-taxon
+++ b/bin/o-create-GG-alignment-template-from-taxon
@@ -11,6 +11,7 @@
 # Please read the COPYING file.
 
 import argparse
+import os
 
 import Oligotyping.lib.fastalib as u
 
@@ -31,8 +32,12 @@ def gen_tmpl(taxon, otu_id_to_greengenes, greengenes_alignment, output_file_path
     ids = list(set(get_ids(taxon, otu_id_to_greengenes)))
 
     print '%d ids found for %s.' % (len(ids), taxon)
-    
-    template = u.FastaOutput('%s.tmpl' % taxon)
+    o_path = '%s.tmpl' % taxon
+
+    if output_file_path:
+       o_path = os.path.join(output_file_path, (taxon + ".tmpl"))
+
+    template = u.FastaOutput(o_path)
     fasta = u.SequenceSource(greengenes_alignment)
     while fasta.next():
         if fasta.id in ids:
@@ -52,7 +57,7 @@ if __name__ == "__main__":
     parser.add_argument('greengenes_alignment', metavar = 'GREENGENES_ALIGNMENT',
                         help = 'Path to the GreenGenes alignment file. You can download it from \
                                "http://greengenes.lbl.gov/Download/OTUs/gg_otus_6oct2010/rep_set/gg_97_otus_6oct2010_aligned.fasta"')
-    parser.add_argument('-o', '--output', help = 'Output file name', default = None)
+    parser.add_argument('-o', '--output', help = 'Path to the output folder', default = None)
 
 
     args = parser.parse_args()


### PR DESCRIPTION
On of my colleges was following this [trade on Google Mail list] (https://groups.google.com/d/msg/oligotyping/U_nz8KR8FCo/UbtpxhSitUkJ), but script failed with ValueError at this [point] (https://github.com/meren/oligotyping/blob/master/bin/o-create-GG-alignment-template-from-taxon#L21). I slightly changed the for loop and wrap it into the function. 
Then I noticed that -o argument is never used, so I changed -o parameter to be a folder path, where $taxon.name.tmpl will be created.